### PR TITLE
Fix bug with content not restoring to portrait version on reorient du…

### DIFF
--- a/public/scripts/aboutView.js
+++ b/public/scripts/aboutView.js
@@ -24,8 +24,8 @@
 //On page load, drop down nameplate nav element (linked to section #projects) and then re-conceal
   $(document).ready(function() {
     console.log('Loaded');
-    $(page).scroll(function() {
-      $('#shadow').filter(':animated').finish();
+    $(window).scroll(function() {
+      $('#shadow').stop(false,true);
     });
     $('#name').addClass('down').animate({marginTop: '+=2.5rem'}, 2500, function() {
       $('#shadow').animate({opacity: 1}).animate({opacity: 0}, 2500);
@@ -91,7 +91,6 @@
       //  -display lefthand "tab" div in .skillsAbs and simultaneously reposition and re-fadeIn content #sections
       $('html, body').animate({scrollTop: 0});
       $('#sections').fadeIn(800);
-      $('.above, .atRight').toggle();
       $('.skillsAbs > div').show().animate({opacity: 1}, {duration: 1200, queue: false});
     });
   };
@@ -121,7 +120,6 @@
     //Reposition/reveal slideshow/nav assembly above/over content
     $('#l-slider').fadeIn().animate({marginLeft: 0}, {duration: 1000});
     // $('.atRight').hide();
-    $('.above, .atRight').toggle();
     $('#shadow').fadeIn(800);
     $('.skillsAbs > div').fadeOut(1000);
     $('.skillsFixed, .wk, #name, #shadow').finish().animate({marginLeft: 0}, 1000);
@@ -136,6 +134,7 @@
     //Checks orientation on page load and device reorientation
     $('page').load(setOtn());
     $(window).on('orientationchange', function() {
+      $('.above, .atRight').toggle();
       console.log('orientation change');
       setOtn();
     });


### PR DESCRIPTION
…ring slider animation:

On landSlider firing setLandscape, if phone was turned back to portrait, #about text would stay synced to landscape-appropriate version.
